### PR TITLE
✨ Add payload and StartEventId to CallActivity model

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/persistence_api",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/persistence_api.contracts/package.json
+++ b/persistence_api.contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/persistence_api.contracts",
-  "version": "1.1.0",
+  "version": "1.1.0-alpha.1",
   "description": "Contains the contracts for the persistence API.",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/persistence_api.contracts/package.json
+++ b/persistence_api.contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/persistence_api.contracts",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Contains the contracts for the persistence API.",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/persistence_api.contracts/src/data_models/process_model/model/activities/call_activity.ts
+++ b/persistence_api.contracts/src/data_models/process_model/model/activities/call_activity.ts
@@ -18,6 +18,16 @@ export class CallActivity extends Activity {
 
   public type: CallActivityType = CallActivityType.Unspecified;
   public calledReference?: string;
+  /**
+   * Optional: The ID of the StartEvent with which to call the CallActivity.
+   * If no ID is provided, the first found StartEventID is used.
+   */
+  public startEventId?: string;
+  /**
+   * Optional: The payload with which to start the CallActivity.
+   * If not provided, the current token is used as a payload.
+   */
+  public payload?: any; // eslint-disable-line
   public bindingType: CallActivityBindingType = CallActivityBindingType.deployment;
   public calledElementVersion?: string;
   public calledElementTenantId: string;

--- a/persistence_api.contracts/src/data_models/process_model/model/events/definitions/error_event_definition.ts
+++ b/persistence_api.contracts/src/data_models/process_model/model/events/definitions/error_event_definition.ts
@@ -7,5 +7,6 @@ export class ErrorEventDefinition extends EventDefinition {
 
   public name: string;
   public code: string;
+  public message: string;
 
 }

--- a/persistence_api.contracts/src/data_models/process_model/model/events/definitions/error_event_definition.ts
+++ b/persistence_api.contracts/src/data_models/process_model/model/events/definitions/error_event_definition.ts
@@ -5,8 +5,8 @@ import {EventDefinition} from './event_definition';
  */
 export class ErrorEventDefinition extends EventDefinition {
 
-  public name: string;
-  public code: string;
-  public message: string;
+  public name?: string;
+  public code?: string;
+  public message?: string;
 
 }

--- a/persistence_api.contracts/src/data_models/process_model/model/global_elements/error.ts
+++ b/persistence_api.contracts/src/data_models/process_model/model/global_elements/error.ts
@@ -1,11 +1,13 @@
 import {BaseElement} from '../base/index';
 
 /**
- * Describes a BPMN error that can be thrown by an ErrorEndEvent.
+ * Describes a global BPMN error element.
+ * Can be thrown by an ErrorEndEvent and caught by an ErrorBoundaryEvent.
  */
 export class Error extends BaseElement {
 
-  public name: string;
-  public code: string;
+  public name?: string;
+  public code?: string;
+  public message?: string;
 
 }

--- a/persistence_api.repositories.sequelize/package.json
+++ b/persistence_api.repositories.sequelize/package.json
@@ -25,7 +25,7 @@
     "@essential-projects/errors_ts": "^1.4.0",
     "@essential-projects/iam_contracts": "^3.4.1",
     "@essential-projects/sequelize_connection_manager": "^3.0.0",
-    "@process-engine/persistence_api.contracts": "1.0.0",
+    "@process-engine/persistence_api.contracts": "feature~add_call_activity_paylad_and_start_event_id",
     "bcryptjs": "^2.4.3",
     "bluebird": "^3.5.2",
     "bluebird-global": "^1.0.1",

--- a/persistence_api.repositories.sequelize/package.json
+++ b/persistence_api.repositories.sequelize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/persistence_api.repositories.sequelize",
-  "version": "1.1.0",
+  "version": "1.1.0-alpha.1",
   "description": "Contains the sequelize-based repository implementation for the persistence API.",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",
@@ -25,7 +25,7 @@
     "@essential-projects/errors_ts": "^1.4.0",
     "@essential-projects/iam_contracts": "^3.4.1",
     "@essential-projects/sequelize_connection_manager": "^3.0.0",
-    "@process-engine/persistence_api.contracts": "feature~add_call_activity_paylad_and_start_event_id",
+    "@process-engine/persistence_api.contracts": "1.1.0-alpha.1",
     "bcryptjs": "^2.4.3",
     "bluebird": "^3.5.2",
     "bluebird-global": "^1.0.1",

--- a/persistence_api.repositories.sequelize/package.json
+++ b/persistence_api.repositories.sequelize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/persistence_api.repositories.sequelize",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Contains the sequelize-based repository implementation for the persistence API.",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/persistence_api.services/package.json
+++ b/persistence_api.services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/persistence_api.services",
-  "version": "1.1.0",
+  "version": "1.1.0-alpha.1",
   "description": "Contains the service layer for the persistence API.",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",
@@ -23,7 +23,7 @@
   "dependencies": {
     "@essential-projects/errors_ts": "^1.4.4",
     "@essential-projects/iam_contracts": "^3.4.1",
-    "@process-engine/persistence_api.contracts": "feature~add_call_activity_paylad_and_start_event_id",
+    "@process-engine/persistence_api.contracts": "1.1.0-alpha.1",
     "bluebird-global": "^1.0.1",
     "clone": "^2.1.2",
     "loggerhythm": "^3.0.3"

--- a/persistence_api.services/package.json
+++ b/persistence_api.services/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@essential-projects/errors_ts": "^1.4.4",
     "@essential-projects/iam_contracts": "^3.4.1",
-    "@process-engine/persistence_api.contracts": "1.0.0",
+    "@process-engine/persistence_api.contracts": "feature~add_call_activity_paylad_and_start_event_id",
     "bluebird-global": "^1.0.1",
     "clone": "^2.1.2",
     "loggerhythm": "^3.0.3"

--- a/persistence_api.services/package.json
+++ b/persistence_api.services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/persistence_api.services",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Contains the service layer for the persistence API.",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/persistence_api.use_cases/package.json
+++ b/persistence_api.use_cases/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/persistence_api.use_cases",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Contains the UseCase layer for the persistence API.",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/persistence_api.use_cases/package.json
+++ b/persistence_api.use_cases/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@essential-projects/iam_contracts": "^3.4.1",
     "@essential-projects/errors_ts": "^1.4.3",
-    "@process-engine/persistence_api.contracts": "1.0.0"
+    "@process-engine/persistence_api.contracts": "feature~add_call_activity_paylad_and_start_event_id"
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",

--- a/persistence_api.use_cases/package.json
+++ b/persistence_api.use_cases/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/persistence_api.use_cases",
-  "version": "1.1.0",
+  "version": "1.1.0-alpha.1",
   "description": "Contains the UseCase layer for the persistence API.",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",
@@ -23,7 +23,7 @@
   "dependencies": {
     "@essential-projects/iam_contracts": "^3.4.1",
     "@essential-projects/errors_ts": "^1.4.3",
-    "@process-engine/persistence_api.contracts": "feature~add_call_activity_paylad_and_start_event_id"
+    "@process-engine/persistence_api.contracts": "1.1.0-alpha.1"
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",


### PR DESCRIPTION
## Changes

1. Add the `startEventId` and `payload` properties to the CallActivity model
2. Fix `ErrorEventDefinition` property declarations
    - Add missing `message` property
    - Make all properties optional
3. Fix global error type (Same as  2.)

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/391
Part of https://github.com/process-engine/process_engine_runtime/issues/430

PR: #1