### PR TITLE
♻️ Unify return values for correlation queries

### DIFF
--- a/persistence_api.repositories.sequelize/package.json
+++ b/persistence_api.repositories.sequelize/package.json
@@ -25,7 +25,7 @@
     "@essential-projects/errors_ts": "^1.4.0",
     "@essential-projects/iam_contracts": "^3.4.1",
     "@essential-projects/sequelize_connection_manager": "^3.0.0",
-    "@process-engine/persistence_api.contracts": "1.1.0-alpha.3",
+    "@process-engine/persistence_api.contracts": "feature~unify_return_values_for_correlation_queries",
     "bcryptjs": "^2.4.3",
     "bluebird": "^3.5.2",
     "bluebird-global": "^1.0.1",

--- a/persistence_api.services/package.json
+++ b/persistence_api.services/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@essential-projects/errors_ts": "^1.4.4",
     "@essential-projects/iam_contracts": "^3.4.1",
-    "@process-engine/persistence_api.contracts": "1.1.0-alpha.3",
+    "@process-engine/persistence_api.contracts": "feature~unify_return_values_for_correlation_queries",
     "bluebird-global": "^1.0.1",
     "clone": "^2.1.2",
     "loggerhythm": "^3.0.3"

--- a/persistence_api.use_cases/package.json
+++ b/persistence_api.use_cases/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@essential-projects/iam_contracts": "^3.4.1",
     "@essential-projects/errors_ts": "^1.4.3",
-    "@process-engine/persistence_api.contracts": "1.1.0-alpha.3"
+    "@process-engine/persistence_api.contracts": "feature~unify_return_values_for_correlation_queries"
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",


### PR DESCRIPTION
## Changes

1. Update tests for list-based ProcessInstance- and Correlation- Queries

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/432

PR: #4

## How to test the changes

- Query correlations or process instances, using an empty database
- See that the return value will be an empty Array

- Try accessing a ProcessInstance started by somebody else
- Get a 404