### PR TITLE
🔒 Account for internal user when filtering ProcessInstances

### DIFF
--- a/persistence_api.services/src/correlation_service.ts
+++ b/persistence_api.services/src/correlation_service.ts
@@ -248,7 +248,7 @@ export class CorrelationService implements ICorrelationService {
     correlationsFromRepo: Array<ProcessInstanceFromRepository>,
   ): Promise<Array<ProcessInstanceFromRepository>> {
 
-    const userIsSuperAdmin = identity.userId !== 'dummy_token' && await this.checkIfUserIsSuperAdmin(identity);
+    const userIsSuperAdmin = await this.checkIfUserIsSuperAdmin(identity);
 
     // Super Admins can always see everything.
     if (userIsSuperAdmin) {
@@ -259,9 +259,10 @@ export class CorrelationService implements ICorrelationService {
 
       // Correlations that were created with the dummy token are visible to everybody.
       const isDummyToken = correlationFromRepo.identity.userId === 'dummy_token';
+      const isInternalToken = correlationFromRepo.identity.userId === 'ProcessEngineInternalUser';
       const userIdsMatch = identity.userId === correlationFromRepo.identity.userId;
 
-      return isDummyToken || userIdsMatch;
+      return isDummyToken || isInternalToken || userIdsMatch;
     });
   }
 


### PR DESCRIPTION
## Changes

Always return ProcessInstances that were started by the internal user.

## Issues

PR: #5

## How to test the changes

This user can only be used by the CronjobService.

- Auto start a few ProcessInstances, using CyclicTimerStartEvents
- Request a list of ProcessInstances/Correlations
- See that those instances are always included in the list