### PR TITLE
🔥 Archive logs from deleted ProcessModels

### DIFF
--- a/persistence_api.contracts/package.json
+++ b/persistence_api.contracts/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",
-    "@process-engine/ci_tools": "^2.0.0",
+    "@process-engine/ci_tools": "2.2.0-beta.3",
     "@types/node": "^10.12.10",
     "eslint": "^5.16.0",
     "tsconfig": "^7.0.0",

--- a/persistence_api.contracts/package.json
+++ b/persistence_api.contracts/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",
-    "@process-engine/ci_tools": "2.2.0-beta.4",
+    "@process-engine/ci_tools": "^2.2.0",
     "@types/node": "^10.12.10",
     "eslint": "^5.16.0",
     "tsconfig": "^7.0.0",

--- a/persistence_api.contracts/package.json
+++ b/persistence_api.contracts/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",
-    "@process-engine/ci_tools": "2.2.0-beta.3",
+    "@process-engine/ci_tools": "2.2.0-beta.4",
     "@types/node": "^10.12.10",
     "eslint": "^5.16.0",
     "tsconfig": "^7.0.0",

--- a/persistence_api.contracts/package.json
+++ b/persistence_api.contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/persistence_api.contracts",
-  "version": "1.1.0-alpha.5",
+  "version": "1.1.0-alpha.6",
   "description": "Contains the contracts for the persistence API.",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/persistence_api.repositories.sequelize/package.json
+++ b/persistence_api.repositories.sequelize/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",
-    "@process-engine/ci_tools": "^2.0.0",
+    "@process-engine/ci_tools": "2.2.0-beta.3",
     "@types/bcryptjs": "^2.4.2",
     "@types/bluebird-global": "^3.5.12",
     "@types/node": "^10.12.10",

--- a/persistence_api.repositories.sequelize/package.json
+++ b/persistence_api.repositories.sequelize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/persistence_api.repositories.sequelize",
-  "version": "1.1.0-alpha.5",
+  "version": "1.1.0-alpha.6",
   "description": "Contains the sequelize-based repository implementation for the persistence API.",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",
@@ -25,7 +25,7 @@
     "@essential-projects/errors_ts": "^1.4.0",
     "@essential-projects/iam_contracts": "^3.4.1",
     "@essential-projects/sequelize_connection_manager": "^3.0.0",
-    "@process-engine/persistence_api.contracts": "1.1.0-alpha.5",
+    "@process-engine/persistence_api.contracts": "1.1.0-alpha.6",
     "bcryptjs": "^2.4.3",
     "bluebird": "^3.5.2",
     "bluebird-global": "^1.0.1",

--- a/persistence_api.repositories.sequelize/package.json
+++ b/persistence_api.repositories.sequelize/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",
-    "@process-engine/ci_tools": "2.2.0-beta.3",
+    "@process-engine/ci_tools": "2.2.0-beta.4",
     "@types/bcryptjs": "^2.4.2",
     "@types/bluebird-global": "^3.5.12",
     "@types/node": "^10.12.10",

--- a/persistence_api.repositories.sequelize/package.json
+++ b/persistence_api.repositories.sequelize/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",
-    "@process-engine/ci_tools": "2.2.0-beta.4",
+    "@process-engine/ci_tools": "^2.2.0",
     "@types/bcryptjs": "^2.4.2",
     "@types/bluebird-global": "^3.5.12",
     "@types/node": "^10.12.10",

--- a/persistence_api.services/package.json
+++ b/persistence_api.services/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",
-    "@process-engine/ci_tools": "2.2.0-beta.4",
+    "@process-engine/ci_tools": "^2.2.0",
     "@types/bluebird-global": "^3.5.9",
     "@types/node": "^10.12.10",
     "eslint": "^5.16.0",

--- a/persistence_api.services/package.json
+++ b/persistence_api.services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/persistence_api.services",
-  "version": "1.1.0-alpha.5",
+  "version": "1.1.0-alpha.6",
   "description": "Contains the service layer for the persistence API.",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",
@@ -23,7 +23,7 @@
   "dependencies": {
     "@essential-projects/errors_ts": "^1.4.4",
     "@essential-projects/iam_contracts": "^3.4.1",
-    "@process-engine/persistence_api.contracts": "1.1.0-alpha.5",
+    "@process-engine/persistence_api.contracts": "1.1.0-alpha.6",
     "bluebird-global": "^1.0.1",
     "clone": "^2.1.2",
     "loggerhythm": "^3.0.3"

--- a/persistence_api.services/package.json
+++ b/persistence_api.services/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",
-    "@process-engine/ci_tools": "2.2.0-beta.3",
+    "@process-engine/ci_tools": "2.2.0-beta.4",
     "@types/bluebird-global": "^3.5.9",
     "@types/node": "^10.12.10",
     "eslint": "^5.16.0",

--- a/persistence_api.services/package.json
+++ b/persistence_api.services/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",
-    "@process-engine/ci_tools": "^2.0.0",
+    "@process-engine/ci_tools": "2.2.0-beta.3",
     "@types/bluebird-global": "^3.5.9",
     "@types/node": "^10.12.10",
     "eslint": "^5.16.0",

--- a/persistence_api.use_cases/ioc_module.js
+++ b/persistence_api.use_cases/ioc_module.js
@@ -5,7 +5,16 @@ const {ProcessModelUseCases} = require('./dist/commonjs/index');
 function registerInContainer(container) {
   container
     .register('ProcessModelUseCases', ProcessModelUseCases)
-    .dependencies('CorrelationService', 'ExternalTaskService', 'FlowNodeInstanceService', 'IamService', 'ProcessModelService');
+    .dependencies(
+      'CorrelationService',
+      'ExternalTaskService',
+      'FlowNodeInstanceService',
+      'IamService',
+      'LoggingApiService',
+      'MetricsApiService',
+      'ProcessModelService',
+    )
+    .singleton();
 }
 
 module.exports.registerInContainer = registerInContainer;

--- a/persistence_api.use_cases/package.json
+++ b/persistence_api.use_cases/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",
-    "@process-engine/ci_tools": "2.2.0-beta.3",
+    "@process-engine/ci_tools": "2.2.0-beta.4",
     "@types/node": "^10.12.10",
     "eslint": "^5.16.0",
     "tsconfig": "^7.0.0",

--- a/persistence_api.use_cases/package.json
+++ b/persistence_api.use_cases/package.json
@@ -23,11 +23,13 @@
   "dependencies": {
     "@essential-projects/iam_contracts": "^3.4.1",
     "@essential-projects/errors_ts": "^1.4.3",
+    "@process-engine/logging_api_contracts": "feature~implement_log_archival",
+    "@process-engine/metrics_api_contracts": "feature~implement_log_archival",
     "@process-engine/persistence_api.contracts": "1.1.0-alpha.5"
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",
-    "@process-engine/ci_tools": "^2.0.0",
+    "@process-engine/ci_tools": "2.2.0-beta.3",
     "@types/node": "^10.12.10",
     "eslint": "^5.16.0",
     "tsconfig": "^7.0.0",

--- a/persistence_api.use_cases/package.json
+++ b/persistence_api.use_cases/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/persistence_api.use_cases",
-  "version": "1.1.0-alpha.5",
+  "version": "1.1.0-alpha.6",
   "description": "Contains the UseCase layer for the persistence API.",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",
@@ -25,7 +25,7 @@
     "@essential-projects/errors_ts": "^1.4.3",
     "@process-engine/logging_api_contracts": "2.0.0-alpha.1",
     "@process-engine/metrics_api_contracts": "3.0.0-alpha.1",
-    "@process-engine/persistence_api.contracts": "1.1.0-alpha.5"
+    "@process-engine/persistence_api.contracts": "1.1.0-alpha.6"
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",

--- a/persistence_api.use_cases/package.json
+++ b/persistence_api.use_cases/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",
-    "@process-engine/ci_tools": "2.2.0-beta.4",
+    "@process-engine/ci_tools": "^2.2.0",
     "@types/node": "^10.12.10",
     "eslint": "^5.16.0",
     "tsconfig": "^7.0.0",

--- a/persistence_api.use_cases/package.json
+++ b/persistence_api.use_cases/package.json
@@ -23,8 +23,8 @@
   "dependencies": {
     "@essential-projects/iam_contracts": "^3.4.1",
     "@essential-projects/errors_ts": "^1.4.3",
-    "@process-engine/logging_api_contracts": "feature~implement_log_archival",
-    "@process-engine/metrics_api_contracts": "feature~implement_log_archival",
+    "@process-engine/logging_api_contracts": "2.0.0-alpha.1",
+    "@process-engine/metrics_api_contracts": "3.0.0-alpha.1",
     "@process-engine/persistence_api.contracts": "1.1.0-alpha.5"
   },
   "devDependencies": {

--- a/persistence_api.use_cases/src/process_model_use_cases.ts
+++ b/persistence_api.use_cases/src/process_model_use_cases.ts
@@ -64,6 +64,7 @@ export class ProcessModelUseCases implements IProcessModelUseCases {
     await this.flowNodeInstanceService.deleteByProcessModelId(processModelId);
     await this.externalTaskService.deleteExternalTasksByProcessModelId(identity, processModelId);
     await this.loggingService.archiveProcessModelLogs(identity, processModelId);
+    await this.metricsService.archiveProcessModelMetrics(identity, processModelId);
   }
 
   public async persistProcessDefinitions(identity: IIdentity, name: string, xml: string, overwriteExisting?: boolean): Promise<void> {

--- a/persistence_api.use_cases/src/process_model_use_cases.ts
+++ b/persistence_api.use_cases/src/process_model_use_cases.ts
@@ -1,5 +1,7 @@
 import {IIAMService, IIdentity} from '@essential-projects/iam_contracts';
 
+import {ILoggingApi} from '@process-engine/logging_api_contracts';
+import {IMetricsApi} from '@process-engine/metrics_api_contracts';
 import {
   ICorrelationService,
   IExternalTaskService,
@@ -19,6 +21,8 @@ export class ProcessModelUseCases implements IProcessModelUseCases {
   private readonly externalTaskService: IExternalTaskService;
   private readonly flowNodeInstanceService: IFlowNodeInstanceService;
   private readonly iamService: IIAMService;
+  private readonly loggingService: ILoggingApi;
+  private readonly metricsService: IMetricsApi;
   private readonly processModelService: IProcessModelService;
 
   constructor(
@@ -26,12 +30,16 @@ export class ProcessModelUseCases implements IProcessModelUseCases {
     externalTaskService: IExternalTaskService,
     flowNodeInstanceService: IFlowNodeInstanceService,
     iamService: IIAMService,
+    loggingService: ILoggingApi,
+    metricsService: IMetricsApi,
     processModelService: IProcessModelService,
   ) {
     this.correlationService = correlationService;
     this.externalTaskService = externalTaskService;
     this.flowNodeInstanceService = flowNodeInstanceService;
     this.iamService = iamService;
+    this.loggingService = loggingService;
+    this.metricsService = metricsService;
     this.processModelService = processModelService;
   }
 
@@ -55,6 +63,7 @@ export class ProcessModelUseCases implements IProcessModelUseCases {
     await this.correlationService.deleteCorrelationByProcessModelId(identity, processModelId);
     await this.flowNodeInstanceService.deleteByProcessModelId(processModelId);
     await this.externalTaskService.deleteExternalTasksByProcessModelId(identity, processModelId);
+    await this.loggingService.archiveProcessModelLogs(identity, processModelId);
   }
 
   public async persistProcessDefinitions(identity: IIdentity, name: string, xml: string, overwriteExisting?: boolean): Promise<void> {


### PR DESCRIPTION
## Changes

1. Add `LoggingService` and `MetricsService` to `ProcessModelUseCase`
2. Archive logs and metrics for each ProcessModel that gets deleted

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/373

PR: #6

## How to test the changes

- Create some logs and metrics for a ProcessModel
- Delete that ProcessModel
- See that the logs and metrics are moved to the `archive` folder
    - Note: If you haven't specified `archive_path` in the config for the Metric- and Logging- Repositories, then the files will be moved to `<output_path>/archive`