### PR TITLE
🔒 Prevent deployment of ProcessModels without events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/persistence_api",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/persistence_api.contracts/package.json
+++ b/persistence_api.contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/persistence_api.contracts",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Contains the contracts for the persistence API.",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/persistence_api.repositories.sequelize/package.json
+++ b/persistence_api.repositories.sequelize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/persistence_api.repositories.sequelize",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Contains the sequelize-based repository implementation for the persistence API.",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",
@@ -25,7 +25,7 @@
     "@essential-projects/errors_ts": "^1.4.0",
     "@essential-projects/iam_contracts": "^3.4.1",
     "@essential-projects/sequelize_connection_manager": "^3.0.0",
-    "@process-engine/persistence_api.contracts": "1.1.1",
+    "@process-engine/persistence_api.contracts": "1.1.2",
     "bcryptjs": "^2.4.3",
     "bluebird": "^3.5.2",
     "bluebird-global": "^1.0.1",

--- a/persistence_api.services/package.json
+++ b/persistence_api.services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/persistence_api.services",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Contains the service layer for the persistence API.",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",
@@ -23,7 +23,7 @@
   "dependencies": {
     "@essential-projects/errors_ts": "^1.4.4",
     "@essential-projects/iam_contracts": "^3.4.1",
-    "@process-engine/persistence_api.contracts": "1.1.1",
+    "@process-engine/persistence_api.contracts": "1.1.2",
     "bluebird-global": "^1.0.1",
     "clone": "^2.1.2",
     "loggerhythm": "^3.0.3"

--- a/persistence_api.services/src/process_model_service.ts
+++ b/persistence_api.services/src/process_model_service.ts
@@ -160,14 +160,6 @@ export class ProcessModelService implements IProcessModelService {
       throw new UnprocessableEntityError(namesDoNotMatchError);
     }
 
-    if (processsModel.id !== name) {
-
-      const namesDoNotMatchError = `The ProcessModel contained within the diagram "${name}" must also use the name "${name}"!`;
-      logger.error(namesDoNotMatchError);
-
-      throw new UnprocessableEntityError(namesDoNotMatchError);
-    }
-
     const processModelHasNoStartEvents = !processsModel.flowNodes.some((flowNode): boolean => flowNode.bpmnType === BpmnType.startEvent);
     if (processModelHasNoStartEvents) {
 

--- a/persistence_api.use_cases/package.json
+++ b/persistence_api.use_cases/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/persistence_api.use_cases",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Contains the UseCase layer for the persistence API.",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",
@@ -24,7 +24,7 @@
     "@essential-projects/iam_contracts": "^3.4.1",
     "@essential-projects/errors_ts": "^1.4.3",
     "@process-engine/logging_api_contracts": "2.0.0",
-    "@process-engine/persistence_api.contracts": "1.1.1"
+    "@process-engine/persistence_api.contracts": "1.1.2"
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",


### PR DESCRIPTION
## Changes

1. Throw an error, when a user attempts to upload a ProcessModel without Start- or End- Events
2. Always return ProcessModels that do not have StartEvents, regardless of the users claims
    - This is to help users discover invalid ProcessModels that may have already been deployed prior to this change 
    - ProcessModels without StartEvents are not executable anyway

## Issues

PR: #8

## How to test the changes

- Try deploying a ProcessModel without a StartEvent or EndEvent
- Get an `UnprocessableEntityError`