### PR TITLE
✨ Add terminatedBy and finishedAt to ProcessInstances

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "meta exec \"npm run build\" --exclude persistence_api",
-    "lint": "meta exec \"npm run lint --fix\" --exclude persistence_api",
+    "lint": "meta exec \"npm run lint-fix\" --exclude persistence_api",
     "postinstall": "minstall --no-hoist aurelia-* --trust-local-modules .",
     "reinstall": "./reinstall.sh",
     "updateContracts": "node scripts/update_contracts.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/persistence_api",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "meta exec \"npm run build\" --exclude persistence_api",
+    "lint": "meta exec \"npm run lint --fix\" --exclude persistence_api",
     "postinstall": "minstall --no-hoist aurelia-* --trust-local-modules .",
     "reinstall": "./reinstall.sh",
     "updateContracts": "node scripts/update_contracts.js"

--- a/persistence_api.contracts/package.json
+++ b/persistence_api.contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/persistence_api.contracts",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Contains the contracts for the persistence API.",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/persistence_api.contracts/src/data_models/correlations/process_instance.ts
+++ b/persistence_api.contracts/src/data_models/correlations/process_instance.ts
@@ -18,5 +18,7 @@ export class ProcessInstance {
   public error: Error;
   public identity: IIdentity;
   public createdAt?: Date;
+  public finishedAt?: Date;
+  public terminatedBy?: IIdentity;
 
 }

--- a/persistence_api.contracts/src/data_models/correlations/process_instance_from_repository.ts
+++ b/persistence_api.contracts/src/data_models/correlations/process_instance_from_repository.ts
@@ -17,5 +17,7 @@ export class ProcessInstanceFromRepository {
   public identity: IIdentity;
   public createdAt: Date;
   public updatedAt: Date;
+  public finishedAt?: Date;
+  public terminatedBy?: IIdentity;
 
 }

--- a/persistence_api.contracts/src/repositories/icorrelation_repository.ts
+++ b/persistence_api.contracts/src/repositories/icorrelation_repository.ts
@@ -137,7 +137,14 @@ export interface ICorrelationRepository {
    * @param  correlationId     The ID of the Correlation to finish erroneously.
    * @param  processInstanceId The ID of the ProcessInstance to finish.
    * @param  error             The error that occurred.
+   * @param  terminatedBy      Optional: If the ProcessInstance was terminated by a user,
+   *                           this will contain the terminating users identity.
    * @throws {NotFoundError}   When no matching correlation was found.
    */
-  finishProcessInstanceInCorrelationWithError(correlationId: string, processInstanceId: string, error: Error): Promise<void>;
+  finishProcessInstanceInCorrelationWithError(
+    correlationId: string,
+    processInstanceId: string,
+    error: Error,
+    terminatedBy?: IIdentity,
+  ): Promise<void>;
 }

--- a/persistence_api.repositories.sequelize/package.json
+++ b/persistence_api.repositories.sequelize/package.json
@@ -30,6 +30,7 @@
     "bluebird": "^3.5.2",
     "bluebird-global": "^1.0.1",
     "loggerhythm": "^3.0.3",
+    "moment": "^2.24.0",
     "node-uuid": "^1.4.8",
     "sequelize": "^5.18.0",
     "sequelize-typescript": "1.1.0-beta.0"

--- a/persistence_api.repositories.sequelize/package.json
+++ b/persistence_api.repositories.sequelize/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/process-engine/persistence_api#readme",
   "dependencies": {
     "@essential-projects/bootstrapper_contracts": "^1.3.0",
-    "@essential-projects/errors_ts": "^1.4.0",
+    "@essential-projects/errors_ts": "^1.6.0",
     "@essential-projects/iam_contracts": "^3.4.1",
     "@essential-projects/sequelize_connection_manager": "^3.0.0",
     "@process-engine/persistence_api.contracts": "feature~add_terminated_by_field",

--- a/persistence_api.repositories.sequelize/package.json
+++ b/persistence_api.repositories.sequelize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/persistence_api.repositories.sequelize",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Contains the sequelize-based repository implementation for the persistence API.",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",
@@ -25,7 +25,7 @@
     "@essential-projects/errors_ts": "^1.4.0",
     "@essential-projects/iam_contracts": "^3.4.1",
     "@essential-projects/sequelize_connection_manager": "^3.0.0",
-    "@process-engine/persistence_api.contracts": "1.2.0",
+    "@process-engine/persistence_api.contracts": "1.3.0",
     "bcryptjs": "^2.4.3",
     "bluebird": "^3.5.2",
     "bluebird-global": "^1.0.1",

--- a/persistence_api.repositories.sequelize/package.json
+++ b/persistence_api.repositories.sequelize/package.json
@@ -25,7 +25,7 @@
     "@essential-projects/errors_ts": "^1.4.0",
     "@essential-projects/iam_contracts": "^3.4.1",
     "@essential-projects/sequelize_connection_manager": "^3.0.0",
-    "@process-engine/persistence_api.contracts": "1.3.0",
+    "@process-engine/persistence_api.contracts": "feature~add_terminated_by_field",
     "bcryptjs": "^2.4.3",
     "bluebird": "^3.5.2",
     "bluebird-global": "^1.0.1",

--- a/persistence_api.repositories.sequelize/src/correlation_repository.ts
+++ b/persistence_api.repositories.sequelize/src/correlation_repository.ts
@@ -5,7 +5,7 @@ import {DestroyOptions, FindOptions} from 'sequelize';
 import {Sequelize, SequelizeOptions} from 'sequelize-typescript';
 
 import {IDisposable} from '@essential-projects/bootstrapper_contracts';
-import {deserializeError, NotFoundError, serializeError} from '@essential-projects/errors_ts';
+import {NotFoundError, deserializeError, serializeError} from '@essential-projects/errors_ts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 import {SequelizeConnectionManager} from '@essential-projects/sequelize_connection_manager';
 

--- a/persistence_api.repositories.sequelize/src/correlation_repository.ts
+++ b/persistence_api.repositories.sequelize/src/correlation_repository.ts
@@ -206,7 +206,13 @@ export class CorrelationRepository implements ICorrelationRepository, IDisposabl
     await matchingCorrelation.save();
   }
 
-  public async finishProcessInstanceInCorrelationWithError(correlationId: string, processInstanceId: string, error: Error, terminatedBy?: IIdentity): Promise<void> {
+  public async finishProcessInstanceInCorrelationWithError(
+    correlationId: string,
+    processInstanceId: string,
+    error: Error,
+    terminatedBy?: IIdentity,
+  ): Promise<void> {
+
     const queryParams: FindOptions = {
       where: {
         correlationId: correlationId,

--- a/persistence_api.repositories.sequelize/src/correlation_repository.ts
+++ b/persistence_api.repositories.sequelize/src/correlation_repository.ts
@@ -267,7 +267,7 @@ export class CorrelationRepository implements ICorrelationRepository, IDisposabl
     processInstance.processInstanceId = dataModel.processInstanceId;
     processInstance.processModelId = dataModel.processModelId;
     processInstance.processModelHash = dataModel.processModelHash;
-    processInstance.parentProcessInstanceId = dataModel.parentProcessInstanceId ?? undefined;
+    processInstance.parentProcessInstanceId = dataModel.parentProcessInstanceId;
     processInstance.identity = dataModel.identity ? this.tryParse(dataModel.identity) : undefined;
     processInstance.createdAt = dataModel.createdAt;
     processInstance.updatedAt = dataModel.updatedAt;

--- a/persistence_api.repositories.sequelize/src/correlation_repository.ts
+++ b/persistence_api.repositories.sequelize/src/correlation_repository.ts
@@ -262,6 +262,8 @@ export class CorrelationRepository implements ICorrelationRepository, IDisposabl
     processInstance.createdAt = dataModel.createdAt;
     processInstance.updatedAt = dataModel.updatedAt;
     processInstance.state = dataModel.state;
+    processInstance.finishedAt = dataModel.finishedAt;
+    processInstance.terminatedBy = dataModel.terminatedBy ? this.tryParse(dataModel.terminatedBy) : undefined;
 
     const dataModelHasError = dataModel.error !== undefined;
     if (dataModelHasError) {

--- a/persistence_api.repositories.sequelize/src/external_task_repository.ts
+++ b/persistence_api.repositories.sequelize/src/external_task_repository.ts
@@ -7,7 +7,7 @@ import {DestroyOptions, FindOptions, Op as Operators} from 'sequelize';
 import {Sequelize, SequelizeOptions} from 'sequelize-typescript';
 
 import {IDisposable} from '@essential-projects/bootstrapper_contracts';
-import {deserializeError, NotFoundError, serializeError} from '@essential-projects/errors_ts';
+import {NotFoundError, deserializeError, serializeError} from '@essential-projects/errors_ts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 import {SequelizeConnectionManager} from '@essential-projects/sequelize_connection_manager';
 import {

--- a/persistence_api.repositories.sequelize/src/external_task_repository.ts
+++ b/persistence_api.repositories.sequelize/src/external_task_repository.ts
@@ -7,7 +7,7 @@ import {DestroyOptions, FindOptions, Op as Operators} from 'sequelize';
 import {Sequelize, SequelizeOptions} from 'sequelize-typescript';
 
 import {IDisposable} from '@essential-projects/bootstrapper_contracts';
-import {BaseError, NotFoundError, isEssentialProjectsError} from '@essential-projects/errors_ts';
+import {deserializeError, NotFoundError, serializeError} from '@essential-projects/errors_ts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 import {SequelizeConnectionManager} from '@essential-projects/sequelize_connection_manager';
 import {
@@ -190,7 +190,7 @@ export class ExternalTaskRepository implements IExternalTaskRepository, IDisposa
       },
     });
 
-    externalTask.error = this.serializeError(error);
+    externalTask.error = serializeError(error);
     externalTask.state = ExternalTaskState.finished;
     externalTask.finishedAt = moment().toDate();
     await externalTask.save();
@@ -208,21 +208,6 @@ export class ExternalTaskRepository implements IExternalTaskRepository, IDisposa
     externalTask.state = ExternalTaskState.finished;
     externalTask.finishedAt = moment().toDate();
     await externalTask.save();
-  }
-
-  private serializeError(error: Error | string): string {
-
-    const errorIsFromEssentialProjects = isEssentialProjectsError(error);
-    if (errorIsFromEssentialProjects) {
-      return (error as BaseError).serialize();
-    }
-
-    const errorIsString = typeof error === 'string';
-    if (errorIsString) {
-      return error as string;
-    }
-
-    return JSON.stringify(error);
   }
 
   /**
@@ -272,16 +257,8 @@ export class ExternalTaskRepository implements IExternalTaskRepository, IDisposa
 
     let error: Error;
 
-    const dataModelHasError = dataModel.error !== undefined;
-    if (dataModelHasError) {
-
-      const essentialProjectsError: Error = this.tryDeserializeEssentialProjectsError(dataModel.error);
-
-      const errorIsFromEssentialProjects = essentialProjectsError !== undefined;
-
-      error = errorIsFromEssentialProjects
-        ? essentialProjectsError
-        : this.tryParse(dataModel.error);
+    if (dataModel.error) {
+      error = deserializeError(dataModel.error);
     }
 
     return [identity, payload, result, error];
@@ -293,14 +270,6 @@ export class ExternalTaskRepository implements IExternalTaskRepository, IDisposa
     } catch (error) {
       // Value is not a JSON - return it as it is.
       return value;
-    }
-  }
-
-  private tryDeserializeEssentialProjectsError(value: string): Error {
-    try {
-      return BaseError.deserialize(value);
-    } catch (error) {
-      return undefined;
     }
   }
 

--- a/persistence_api.repositories.sequelize/src/flow_node_instance_repository.ts
+++ b/persistence_api.repositories.sequelize/src/flow_node_instance_repository.ts
@@ -668,8 +668,7 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository, 
     runtimeFlowNodeInstance.parentProcessInstanceId = dataModel.parentProcessInstanceId;
     runtimeFlowNodeInstance.previousFlowNodeInstanceId = dataModel.previousFlowNodeInstanceId;
 
-    const dataModelHasError = dataModel.error !== undefined;
-    if (dataModelHasError) {
+    if (dataModel.error) {
       // TODO: Fix type of "error" property - is "string", should be "Error"
       runtimeFlowNodeInstance.error = <any> deserializeError(dataModel.error);
     }

--- a/persistence_api.repositories.sequelize/src/flow_node_instance_repository.ts
+++ b/persistence_api.repositories.sequelize/src/flow_node_instance_repository.ts
@@ -4,7 +4,7 @@ import {DestroyOptions, Op as Operators, Transaction} from 'sequelize';
 import {Sequelize, SequelizeOptions} from 'sequelize-typescript';
 
 import {IDisposable} from '@essential-projects/bootstrapper_contracts';
-import {deserializeError, NotFoundError, serializeError} from '@essential-projects/errors_ts';
+import {NotFoundError, deserializeError, serializeError} from '@essential-projects/errors_ts';
 import {SequelizeConnectionManager} from '@essential-projects/sequelize_connection_manager';
 import {
   BpmnType,

--- a/persistence_api.repositories.sequelize/src/flow_node_instance_repository.ts
+++ b/persistence_api.repositories.sequelize/src/flow_node_instance_repository.ts
@@ -4,7 +4,7 @@ import {DestroyOptions, Op as Operators, Transaction} from 'sequelize';
 import {Sequelize, SequelizeOptions} from 'sequelize-typescript';
 
 import {IDisposable} from '@essential-projects/bootstrapper_contracts';
-import {BaseError, NotFoundError, isEssentialProjectsError} from '@essential-projects/errors_ts';
+import {deserializeError, NotFoundError, serializeError} from '@essential-projects/errors_ts';
 import {SequelizeConnectionManager} from '@essential-projects/sequelize_connection_manager';
 import {
   BpmnType,
@@ -611,7 +611,7 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository, 
 
     const stateChangeHasErrorAttached = error !== undefined;
     if (stateChangeHasErrorAttached) {
-      matchingFlowNodeInstance.error = this.serializeError(error);
+      matchingFlowNodeInstance.error = serializeError(error);
     }
 
     const createTransaction = await this.sequelizeInstance.transaction();
@@ -651,21 +651,6 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository, 
     await ProcessTokenModel.create(createParams, {transaction: createTransaction});
   }
 
-  private serializeError(error: Error | string): string {
-
-    const errorIsFromEssentialProjects = isEssentialProjectsError(error);
-    if (errorIsFromEssentialProjects) {
-      return (error as BaseError).serialize();
-    }
-
-    const errorIsString = typeof error === 'string';
-    if (errorIsString) {
-      return error as string;
-    }
-
-    return JSON.stringify(error);
-  }
-
   private convertFlowNodeInstanceToRuntimeObject(dataModel: FlowNodeInstanceModel): FlowNodeInstance {
 
     const runtimeFlowNodeInstance = new FlowNodeInstance();
@@ -685,14 +670,8 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository, 
 
     const dataModelHasError = dataModel.error !== undefined;
     if (dataModelHasError) {
-
-      const essentialProjectsError = this.tryDeserializeEssentialProjectsError(dataModel.error);
-
-      const errorIsFromEssentialProjects = essentialProjectsError !== undefined;
-
-      runtimeFlowNodeInstance.error = errorIsFromEssentialProjects
-        ? essentialProjectsError
-        : this.tryParse(dataModel.error);
+      // TODO: Fix type of "error" property - is "string", should be "Error"
+      runtimeFlowNodeInstance.error = <any> deserializeError(dataModel.error);
     }
 
     const processTokens = dataModel.processTokens.map((currentToken: ProcessTokenModel): ProcessToken => {
@@ -728,14 +707,6 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository, 
     } catch (error) {
       // Value is not a JSON - return it as it is.
       return value;
-    }
-  }
-
-  private tryDeserializeEssentialProjectsError(value: string): Error {
-    try {
-      return BaseError.deserialize(value);
-    } catch (error) {
-      return undefined;
     }
   }
 

--- a/persistence_api.repositories.sequelize/src/process_definition_repository.ts
+++ b/persistence_api.repositories.sequelize/src/process_definition_repository.ts
@@ -122,7 +122,8 @@ export class ProcessDefinitionRepository implements IProcessDefinitionRepository
     // We cannot simply use something like "GROUP BY name", because Postgres won't allow it on non-index columns.
     const processDefinitions = await Promise.map<string, ProcessDefinitionModel>(namesAsString, this.getProcessDefinitionByName.bind(this));
 
-    const runtimeProcessDefinitions = processDefinitions.map<ProcessDefinitionFromRepository>(this.convertToProcessDefinitionRuntimeObject.bind(this));
+    const runtimeProcessDefinitions = processDefinitions
+      .map<ProcessDefinitionFromRepository>(this.convertToProcessDefinitionRuntimeObject.bind(this));
 
     return runtimeProcessDefinitions;
   }
@@ -224,7 +225,7 @@ export class ProcessDefinitionRepository implements IProcessDefinitionRepository
 
   private convertToProcessDefinitionRuntimeObject(dataModel: ProcessDefinitionModel): ProcessDefinitionFromRepository {
 
-    function tryParse(value) {
+    function tryParse(value): IIdentity {
       try {
         return JSON.parse(value);
       } catch (error) {

--- a/persistence_api.repositories.sequelize/src/schemas/correlation.ts
+++ b/persistence_api.repositories.sequelize/src/schemas/correlation.ts
@@ -39,6 +39,14 @@ export class CorrelationModel extends Model<CorrelationModel> {
   @Column
   public parentProcessInstanceId: string;
 
+  @AllowNull(true)
+  @Column(DataType.DATE)
+  public finishedAt?: Date;
+
+  @AllowNull(true)
+  @Column(DataType.TEXT)
+  public terminatedBy?: string;
+
   @CreatedAt
   public createdAt?: Date;
 

--- a/persistence_api.services/package.json
+++ b/persistence_api.services/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/process-engine/persistence_api#readme",
   "dependencies": {
-    "@essential-projects/errors_ts": "^1.4.4",
+    "@essential-projects/errors_ts": "^1.6.0",
     "@essential-projects/iam_contracts": "^3.4.1",
     "@process-engine/persistence_api.contracts": "feature~add_terminated_by_field",
     "bluebird-global": "^1.0.1",

--- a/persistence_api.services/package.json
+++ b/persistence_api.services/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@essential-projects/errors_ts": "^1.4.4",
     "@essential-projects/iam_contracts": "^3.4.1",
-    "@process-engine/persistence_api.contracts": "1.3.0",
+    "@process-engine/persistence_api.contracts": "feature~add_terminated_by_field",
     "bluebird-global": "^1.0.1",
     "clone": "^2.1.2",
     "loggerhythm": "^3.0.3"

--- a/persistence_api.services/package.json
+++ b/persistence_api.services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/persistence_api.services",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Contains the service layer for the persistence API.",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",
@@ -23,7 +23,7 @@
   "dependencies": {
     "@essential-projects/errors_ts": "^1.4.4",
     "@essential-projects/iam_contracts": "^3.4.1",
-    "@process-engine/persistence_api.contracts": "1.2.0",
+    "@process-engine/persistence_api.contracts": "1.3.0",
     "bluebird-global": "^1.0.1",
     "clone": "^2.1.2",
     "loggerhythm": "^3.0.3"

--- a/persistence_api.services/src/correlation_service.ts
+++ b/persistence_api.services/src/correlation_service.ts
@@ -355,6 +355,8 @@ export class CorrelationService implements ICorrelationService {
     processInstance.createdAt = processInstanceFromRepo.createdAt;
     processInstance.state = processInstanceFromRepo.state;
     processInstance.identity = processInstanceFromRepo.identity;
+    processInstance.finishedAt = processInstanceFromRepo.finishedAt;
+    processInstance.terminatedBy = processInstanceFromRepo.terminatedBy;
 
     const processInstanceHasErrorAttached = processInstanceFromRepo.error !== undefined && processInstanceFromRepo.error !== null;
     if (processInstanceHasErrorAttached) {

--- a/persistence_api.services/src/correlation_service.ts
+++ b/persistence_api.services/src/correlation_service.ts
@@ -40,7 +40,6 @@ export class CorrelationService implements ICorrelationService {
     iamService: IIAMService,
     processDefinitionRepository: IProcessDefinitionRepository,
   ) {
-
     this.correlationRepository = correlationRepository;
     this.iamService = iamService;
     this.processDefinitionRepository = processDefinitionRepository;
@@ -243,7 +242,15 @@ export class CorrelationService implements ICorrelationService {
     error: Error,
   ): Promise<void> {
     await this.ensureUserHasClaim(identity, canReadProcessModelClaim);
-    await this.correlationRepository.finishProcessInstanceInCorrelationWithError(correlationId, processInstanceId, error);
+
+    const terminatedByUserRegEx = /terminated by user/i;
+    const isTerminationError = terminatedByUserRegEx.test(error.message);
+
+    if (isTerminationError) {
+      await this.correlationRepository.finishProcessInstanceInCorrelationWithError(correlationId, processInstanceId, error, identity);
+    } else {
+      await this.correlationRepository.finishProcessInstanceInCorrelationWithError(correlationId, processInstanceId, error);
+    }
   }
 
   private async filterProcessInstancesFromRepoByIdentity(
@@ -325,8 +332,7 @@ export class CorrelationService implements ICorrelationService {
           ? processInstanceFromRepo.state
           : CorrelationState.running;
 
-        const processInstanceHasErrorAttached = processInstanceFromRepo.error !== undefined && processInstanceFromRepo.error !== null;
-        if (processInstanceHasErrorAttached) {
+        if (processInstanceFromRepo.error) {
           correlation.state = CorrelationState.error;
           correlation.error = processInstanceFromRepo.error;
         }
@@ -358,10 +364,7 @@ export class CorrelationService implements ICorrelationService {
     processInstance.finishedAt = processInstanceFromRepo.finishedAt;
     processInstance.terminatedBy = processInstanceFromRepo.terminatedBy;
 
-    const processInstanceHasErrorAttached = processInstanceFromRepo.error !== undefined && processInstanceFromRepo.error !== null;
-    if (processInstanceHasErrorAttached) {
-      processInstance.error = processInstanceFromRepo.error;
-    }
+    processInstance.error = processInstanceFromRepo.error;
 
     return processInstance;
   }

--- a/persistence_api.use_cases/package.json
+++ b/persistence_api.use_cases/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/process-engine/persistence_api#readme",
   "dependencies": {
     "@essential-projects/iam_contracts": "^3.4.1",
-    "@essential-projects/errors_ts": "^1.4.3",
+    "@essential-projects/errors_ts": "^1.6.0",
     "@process-engine/logging_api_contracts": "2.0.0",
     "@process-engine/persistence_api.contracts": "feature~add_terminated_by_field"
   },

--- a/persistence_api.use_cases/package.json
+++ b/persistence_api.use_cases/package.json
@@ -24,7 +24,7 @@
     "@essential-projects/iam_contracts": "^3.4.1",
     "@essential-projects/errors_ts": "^1.4.3",
     "@process-engine/logging_api_contracts": "2.0.0",
-    "@process-engine/persistence_api.contracts": "1.3.0"
+    "@process-engine/persistence_api.contracts": "feature~add_terminated_by_field"
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",

--- a/persistence_api.use_cases/package.json
+++ b/persistence_api.use_cases/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/persistence_api.use_cases",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Contains the UseCase layer for the persistence API.",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",
@@ -24,7 +24,7 @@
     "@essential-projects/iam_contracts": "^3.4.1",
     "@essential-projects/errors_ts": "^1.4.3",
     "@process-engine/logging_api_contracts": "2.0.0",
-    "@process-engine/persistence_api.contracts": "1.2.0"
+    "@process-engine/persistence_api.contracts": "1.3.0"
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",


### PR DESCRIPTION
## Changes

1. Add optional `terminatedBy` and `finishedAt` columns to Processinstance model
2. Only pass identity of terminating user to the repository, if the ProcessInstance was actually terminated by a user
3. Add matching columns to the `Correlation` DB Schema
4. Remove some nonsensical conditions from ProcessInstance conversion
5. Remove all error serialization and use `serializeError` and `deserializeError` from `@essential-projects/errors_ts@1.6.0` instead

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/478

PR: #9

## How to test the changes

- Run a few ProcessInstances and terminate them through a TerminateEndEvent or manually
- Note that the ProcessInstances that terminated through a TerminateEndEvent will not have a value for `terminatedBy`
- Note that the ProcessInstances you terminated manually _will_ have such an identity