### PR TITLE
♻️ Always sort by "createdAt DESC"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/persistence_api",
-  "version": "1.3.0-alpha.3",
+  "version": "1.4.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/persistence_api.contracts/package.json
+++ b/persistence_api.contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/persistence_api.contracts",
-  "version": "1.3.0",
+  "version": "1.4.0-alpha.1",
   "description": "Contains the contracts for the persistence API.",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/persistence_api.repositories.sequelize/package.json
+++ b/persistence_api.repositories.sequelize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/persistence_api.repositories.sequelize",
-  "version": "1.3.0",
+  "version": "1.4.0-alpha.1",
   "description": "Contains the sequelize-based repository implementation for the persistence API.",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",
@@ -25,7 +25,7 @@
     "@essential-projects/errors_ts": "^1.6.0",
     "@essential-projects/iam_contracts": "^3.4.1",
     "@essential-projects/sequelize_connection_manager": "^3.0.0",
-    "@process-engine/persistence_api.contracts": "1.3.0",
+    "@process-engine/persistence_api.contracts": "1.4.0-alpha.1",
     "bcryptjs": "^2.4.3",
     "bluebird": "^3.5.2",
     "bluebird-global": "^1.0.1",

--- a/persistence_api.repositories.sequelize/package.json
+++ b/persistence_api.repositories.sequelize/package.json
@@ -25,7 +25,7 @@
     "@essential-projects/errors_ts": "^1.6.0",
     "@essential-projects/iam_contracts": "^3.4.1",
     "@essential-projects/sequelize_connection_manager": "^3.0.0",
-    "@process-engine/persistence_api.contracts": "1.4.0-alpha.1",
+    "@process-engine/persistence_api.contracts": "feature~unify_sort_directions",
     "bcryptjs": "^2.4.3",
     "bluebird": "^3.5.2",
     "bluebird-global": "^1.0.1",

--- a/persistence_api.repositories.sequelize/package.json
+++ b/persistence_api.repositories.sequelize/package.json
@@ -25,7 +25,7 @@
     "@essential-projects/errors_ts": "^1.6.0",
     "@essential-projects/iam_contracts": "^3.4.1",
     "@essential-projects/sequelize_connection_manager": "^3.0.0",
-    "@process-engine/persistence_api.contracts": "feature~unify_sort_directions",
+    "@process-engine/persistence_api.contracts": "1.4.0-alpha.1",
     "bcryptjs": "^2.4.3",
     "bluebird": "^3.5.2",
     "bluebird-global": "^1.0.1",

--- a/persistence_api.repositories.sequelize/src/correlation_repository.ts
+++ b/persistence_api.repositories.sequelize/src/correlation_repository.ts
@@ -79,6 +79,7 @@ export class CorrelationRepository implements ICorrelationRepository, IDisposabl
   public async getAll(offset: number = 0, limit: number = 0): Promise<Array<ProcessInstanceFromRepository>> {
 
     const correlations = await CorrelationModel.findAll({
+      order: [['createdAt', 'DESC']],
       ...this.buildPagination(offset, limit),
     });
 
@@ -93,7 +94,7 @@ export class CorrelationRepository implements ICorrelationRepository, IDisposabl
       where: {
         correlationId: correlationId,
       },
-      order: [['createdAt', 'ASC']],
+      order: [['createdAt', 'DESC']],
       ...this.buildPagination(offset, limit),
     };
 
@@ -110,7 +111,7 @@ export class CorrelationRepository implements ICorrelationRepository, IDisposabl
       where: {
         processModelId: processModelId,
       },
-      order: [['createdAt', 'ASC']],
+      order: [['createdAt', 'DESC']],
       ...this.buildPagination(offset, limit),
     };
 
@@ -150,7 +151,7 @@ export class CorrelationRepository implements ICorrelationRepository, IDisposabl
       where: {
         parentProcessInstanceId: processInstanceId,
       },
-      order: [['createdAt', 'ASC']],
+      order: [['createdAt', 'DESC']],
       ...this.buildPagination(offset, limit),
     };
 

--- a/persistence_api.repositories.sequelize/src/cronjob_history_repository.ts
+++ b/persistence_api.repositories.sequelize/src/cronjob_history_repository.ts
@@ -59,6 +59,7 @@ export class CronjobHistoryRepository implements ICronjobHistoryRepository, IDis
 
     const cronjobHistories = await CronjobHistoryEntryModel.findAll({
       ...this.buildPagination(offset, limit),
+      order: [['createdAt', 'DESC']],
     });
 
     const cronjobHistoriesRuntime = cronjobHistories.map<Cronjob>(this.convertToCronjobRuntimeObject.bind(this));

--- a/persistence_api.repositories.sequelize/src/external_task_repository.ts
+++ b/persistence_api.repositories.sequelize/src/external_task_repository.ts
@@ -108,6 +108,7 @@ export class ExternalTaskRepository implements IExternalTaskRepository, IDisposa
         processInstanceId: processInstanceId,
         flowNodeInstanceId: flowNodeInstanceId,
       },
+      order: [['createdAt', 'DESC']],
     });
 
     if (!result) {
@@ -141,6 +142,7 @@ export class ExternalTaskRepository implements IExternalTaskRepository, IDisposa
           ],
         },
       },
+      order: [['createdAt', 'DESC']],
     };
 
     if (maxTasks > 0) {

--- a/persistence_api.repositories.sequelize/src/flow_node_instance_repository.ts
+++ b/persistence_api.repositories.sequelize/src/flow_node_instance_repository.ts
@@ -125,7 +125,7 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository, 
         required: true,
       }],
       order: [
-        ['processTokens', 'createdAt'],
+        ['createdAt', 'DESC'],
       ],
       ...this.buildPagination(offset, limit),
     });
@@ -146,7 +146,7 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository, 
         required: true,
       }],
       order: [
-        ['id', 'ASC'],
+        ['createdAt', 'DESC'],
       ],
       ...this.buildPagination(offset, limit),
     });
@@ -169,6 +169,9 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository, 
         as: 'processTokens',
         required: true,
       }],
+      order: [
+        ['createdAt', 'DESC'],
+      ],
       ...this.buildPagination(offset, limit),
     });
 
@@ -191,6 +194,9 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository, 
         as: 'processTokens',
         required: true,
       }],
+      order: [
+        ['createdAt', 'DESC'],
+      ],
       ...this.buildPagination(offset, limit),
     });
 
@@ -219,6 +225,9 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository, 
         as: 'processTokens',
         required: true,
       }],
+      order: [
+        ['createdAt', 'DESC'],
+      ],
       ...this.buildPagination(offset, limit),
     });
 
@@ -239,7 +248,7 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository, 
         required: true,
       }],
       order: [
-        ['id', 'ASC'],
+        ['createdAt', 'DESC'],
       ],
       ...this.buildPagination(offset, limit),
     });
@@ -260,7 +269,7 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository, 
         required: true,
       }],
       order: [
-        ['id', 'ASC'],
+        ['createdAt', 'DESC'],
       ],
       ...this.buildPagination(offset, limit),
     });
@@ -282,7 +291,7 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository, 
         required: true,
       }],
       order: [
-        ['id', 'ASC'],
+        ['createdAt', 'DESC'],
       ],
       ...this.buildPagination(offset, limit),
     });
@@ -309,6 +318,9 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository, 
         as: 'processTokens',
         required: true,
       }],
+      order: [
+        ['createdAt', 'DESC'],
+      ],
       ...this.buildPagination(offset, limit),
     });
 
@@ -330,7 +342,7 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository, 
         required: true,
       }],
       order: [
-        ['id', 'ASC'],
+        ['createdAt', 'DESC'],
       ],
       ...this.buildPagination(offset, limit),
     });
@@ -353,7 +365,7 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository, 
         required: true,
       }],
       order: [
-        ['id', 'ASC'],
+        ['createdAt', 'DESC'],
       ],
       ...this.buildPagination(offset, limit),
     });
@@ -376,7 +388,7 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository, 
         required: true,
       }],
       order: [
-        ['id', 'ASC'],
+        ['createdAt', 'DESC'],
       ],
       ...this.buildPagination(offset, limit),
     });
@@ -398,7 +410,7 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository, 
         required: true,
       }],
       order: [
-        ['id', 'ASC'],
+        ['createdAt', 'DESC'],
       ],
       ...this.buildPagination(offset, limit),
     });
@@ -430,7 +442,7 @@ export class FlowNodeInstanceRepository implements IFlowNodeInstanceRepository, 
         required: true,
       }],
       order: [
-        ['id', 'ASC'],
+        ['createdAt', 'DESC'],
       ],
       ...this.buildPagination(offset, limit),
     });

--- a/persistence_api.repositories.sequelize/src/process_definition_repository.ts
+++ b/persistence_api.repositories.sequelize/src/process_definition_repository.ts
@@ -110,6 +110,7 @@ export class ProcessDefinitionRepository implements IProcessDefinitionRepository
     const names = await ProcessDefinitionModel.findAll({
       attributes: ['name'],
       group: 'name',
+      order: [['createdAt', 'DESC']],
     });
 
     const namesAsString = names.map((entry: ProcessDefinitionModel): string => {
@@ -153,16 +154,6 @@ export class ProcessDefinitionRepository implements IProcessDefinitionRepository
     return definitonRuntime;
   }
 
-  public async deleteProcessDefinitionById(processModelId: string): Promise<void> {
-    const queryParams: DestroyOptions = {
-      where: {
-        name: processModelId,
-      },
-    };
-
-    await ProcessDefinitionModel.destroy(queryParams);
-  }
-
   public async getHistoryByName(name: string): Promise<Array<ProcessDefinitionFromRepository>> {
 
     const query: FindOptions = {
@@ -203,6 +194,16 @@ export class ProcessDefinitionRepository implements IProcessDefinitionRepository
     const definitonRuntime = this.convertToProcessDefinitionRuntimeObject(definition);
 
     return definitonRuntime;
+  }
+
+  public async deleteProcessDefinitionById(processModelId: string): Promise<void> {
+    const queryParams: DestroyOptions = {
+      where: {
+        name: processModelId,
+      },
+    };
+
+    await ProcessDefinitionModel.destroy(queryParams);
   }
 
   private async createHashForProcessDefinition(xml: string): Promise<string> {

--- a/persistence_api.services/package.json
+++ b/persistence_api.services/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@essential-projects/errors_ts": "^1.6.0",
     "@essential-projects/iam_contracts": "^3.4.1",
-    "@process-engine/persistence_api.contracts": "feature~unify_sort_directions",
+    "@process-engine/persistence_api.contracts": "1.4.0-alpha.1",
     "bluebird-global": "^1.0.1",
     "clone": "^2.1.2",
     "loggerhythm": "^3.0.3"

--- a/persistence_api.services/package.json
+++ b/persistence_api.services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/persistence_api.services",
-  "version": "1.3.0",
+  "version": "1.4.0-alpha.1",
   "description": "Contains the service layer for the persistence API.",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",
@@ -23,7 +23,7 @@
   "dependencies": {
     "@essential-projects/errors_ts": "^1.6.0",
     "@essential-projects/iam_contracts": "^3.4.1",
-    "@process-engine/persistence_api.contracts": "1.3.0",
+    "@process-engine/persistence_api.contracts": "1.4.0-alpha.1",
     "bluebird-global": "^1.0.1",
     "clone": "^2.1.2",
     "loggerhythm": "^3.0.3"

--- a/persistence_api.services/package.json
+++ b/persistence_api.services/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@essential-projects/errors_ts": "^1.6.0",
     "@essential-projects/iam_contracts": "^3.4.1",
-    "@process-engine/persistence_api.contracts": "1.4.0-alpha.1",
+    "@process-engine/persistence_api.contracts": "feature~unify_sort_directions",
     "bluebird-global": "^1.0.1",
     "clone": "^2.1.2",
     "loggerhythm": "^3.0.3"

--- a/persistence_api.use_cases/package.json
+++ b/persistence_api.use_cases/package.json
@@ -24,7 +24,7 @@
     "@essential-projects/iam_contracts": "^3.4.1",
     "@essential-projects/errors_ts": "^1.6.0",
     "@process-engine/logging_api_contracts": "2.0.0",
-    "@process-engine/persistence_api.contracts": "feature~unify_sort_directions"
+    "@process-engine/persistence_api.contracts": "1.4.0-alpha.1"
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",

--- a/persistence_api.use_cases/package.json
+++ b/persistence_api.use_cases/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/persistence_api.use_cases",
-  "version": "1.3.0",
+  "version": "1.4.0-alpha.1",
   "description": "Contains the UseCase layer for the persistence API.",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",
@@ -24,7 +24,7 @@
     "@essential-projects/iam_contracts": "^3.4.1",
     "@essential-projects/errors_ts": "^1.6.0",
     "@process-engine/logging_api_contracts": "2.0.0",
-    "@process-engine/persistence_api.contracts": "1.3.0"
+    "@process-engine/persistence_api.contracts": "1.4.0-alpha.1"
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",

--- a/persistence_api.use_cases/package.json
+++ b/persistence_api.use_cases/package.json
@@ -24,7 +24,7 @@
     "@essential-projects/iam_contracts": "^3.4.1",
     "@essential-projects/errors_ts": "^1.6.0",
     "@process-engine/logging_api_contracts": "2.0.0",
-    "@process-engine/persistence_api.contracts": "1.4.0-alpha.1"
+    "@process-engine/persistence_api.contracts": "feature~unify_sort_directions"
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",


### PR DESCRIPTION
## Changes

Use `createdAt DESC` as the default sorting parameter for every query that returns a list.

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/507

PR: #11

## How to test the changes

- Use any query that returns a list
- See that they are all sorted by "createdAt" in a "descending" order